### PR TITLE
Workflow change

### DIFF
--- a/app/src/apps/chorus_dt.py
+++ b/app/src/apps/chorus_dt.py
@@ -122,22 +122,22 @@ layout = html.Div(
 )
 
 
-@app.callback(Output("selected-entity-show", "children"), [Input("selected-entity", "children")])
+@app.callback(Output("selected-entity-show", "children"), [Input("dashboard-selected-entity", "children")])
 def on_selected_entity_fill_tabs_data(selected_entity):
     if selected_entity is not None:
-        organization, service = oc.get_organization_service(selected_entity)
+        service = oc.get_entity_by_id(selected_entity)
         return "Organisation : " + organization.label + ", Service : " + service.label
     else:
         return "empty"
 
 
-@app.callback(Output("timeseries-chorus-dt", "figure"), [Input("selected-entity", "children")])
+@app.callback(Output("timeseries-chorus-dt", "figure"), [Input("dashboard-selected-entity", "children")])
 def update_emissions_timeseries(selected_entity):
-    organization, service = oc.get_organization_service(selected_entity)
+    service = oc.get_entity_by_id(selected_entity)
     return get_emissions_timeseries(service.code_chorus)
 
 
-@app.callback(Output("donut-by-prestation", "figure"), [Input("selected-entity", "children")])
+@app.callback(Output("donut-by-prestation", "figure"), [Input("dashboard-selected-entity", "children")])
 def update_donut_by_prestation(selected_entity):
-    organization, service = oc.get_organization_service(selected_entity)
+    service = oc.get_entity_by_id(selected_entity)
     return get_donut_by_prestation_type(service.code_chorus)

--- a/app/src/apps/chorus_dt.py
+++ b/app/src/apps/chorus_dt.py
@@ -70,7 +70,6 @@ layout = html.Div(
             [
                 dbc.Col(
                     [
-                        html.B("", id="selected-entity-show"),
                         dbc.Card(
                             dbc.CardBody(
                                 [
@@ -120,15 +119,6 @@ layout = html.Div(
     ],
     id="div-data-chorus-dt",
 )
-
-
-@app.callback(Output("selected-entity-show", "children"), [Input("dashboard-selected-entity", "children")])
-def on_selected_entity_fill_tabs_data(selected_entity):
-    if selected_entity is not None:
-        service = oc.get_entity_by_id(selected_entity)
-        return "Organisation : " + organization.label + ", Service : " + service.label
-    else:
-        return "empty"
 
 
 @app.callback(Output("timeseries-chorus-dt", "figure"), [Input("dashboard-selected-entity", "children")])

--- a/app/src/apps/dashboard.py
+++ b/app/src/apps/dashboard.py
@@ -16,6 +16,8 @@ from utils.organization_chart import oc
 layout = html.Div(
     id="div-data-display",
     children=[
+        html.Div(id="dashboard-selected-entity", style={"display": "none"}),
+        html.Div(id="dashboard-selected-entity-show"),
         dbc.Tabs(
             id="tabs-datasets",
             children=[
@@ -25,7 +27,6 @@ layout = html.Div(
             ],
             active_tab="chorus-dt",
         ),
-        html.Div(id="dashboard-selected-entity", style={"display": "none"}),
         html.Div(id="tabs-content"),
     ],
     style={"display": "none"},
@@ -37,6 +38,19 @@ def parse_pathname(pathname):
     # Parsing the pathname which should be tableau_de_bord/{entity_id}
     entity_id = pathname.rsplit("/")[-1]
     return entity_id
+
+
+@app.callback(Output("dashboard-selected-entity-show", "children"), [Input("dashboard-selected-entity", "children")])
+def on_selected_entity_show_selected_entity(selected_entity):
+    if selected_entity is not None:
+        service = oc.get_entity_by_id(selected_entity)
+        return html.Div(
+            [
+                html.H3(service.parent.label, style={"text-align": "center"}),
+                html.Br(),
+                html.H4(service.label, style={"text-align": "center"}),
+            ]
+        )
 
 
 @app.callback(

--- a/app/src/apps/dashboard.py
+++ b/app/src/apps/dashboard.py
@@ -32,14 +32,11 @@ layout = html.Div(
 )
 
 
-@app.callback(Output("dashboard-selected-entity", "children"), [Input("url", "search")])
-def parse_pathname(search):
-    # Parsing the search parameters which will be of the form ?entite=3
-    search = parse_qs(search.strip("?"))
-    if "entite" not in search:
-        return None
-    else:
-        return search["entite"][0]
+@app.callback(Output("dashboard-selected-entity", "children"), [Input("url", "pathname")])
+def parse_pathname(pathname):
+    # Parsing the pathname which should be tableau_de_bord/{entity_id}
+    entity_id = pathname.rsplit("/")[-1]
+    return entity_id
 
 
 @app.callback(

--- a/app/src/apps/dashboard.py
+++ b/app/src/apps/dashboard.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs
+
 import dash_core_components as dcc
 import dash_html_components as html
 import dash_bootstrap_components as dbc
@@ -8,6 +10,8 @@ from apps import odrive
 from apps import osfi
 
 from app import app
+
+from utils.organization_chart import oc
 
 layout = html.Div(
     id="div-data-display",
@@ -21,14 +25,27 @@ layout = html.Div(
             ],
             active_tab="chorus-dt",
         ),
+        html.Div(id="dashboard-selected-entity", style={"display": "none"}),
         html.Div(id="tabs-content"),
     ],
     style={"display": "none"},
 )
 
 
+@app.callback(Output("dashboard-selected-entity", "children"), [Input("url", "search")])
+def parse_pathname(search):
+    # Parsing the search parameters which will be of the form ?entite=3
+    search = parse_qs(search.strip("?"))
+    if "entite" not in search:
+        return None
+    else:
+        return search["entite"][0]
+
+
 @app.callback(
-    Output("div-data-display", "style"), [Input("selected-entity", "children")], [State("div-data-display", "style")]
+    Output("div-data-display", "style"),
+    [Input("dashboard-selected-entity", "children")],
+    [State("div-data-display", "style")],
 )
 def on_selected_entity_toggle_tabs(selected_entity, style):
     if selected_entity is not None:
@@ -40,11 +57,11 @@ def on_selected_entity_toggle_tabs(selected_entity, style):
 
 
 @app.callback(
-    Output("tabs-content", "children"), [Input("selected-entity", "children"), Input("tabs-datasets", "active_tab")]
+    Output("tabs-content", "children"),
+    [Input("dashboard-selected-entity", "children"), Input("tabs-datasets", "active_tab")],
 )
 def on_selected_entity_fill_tabs_data(selected_entity, active_tab):
     if selected_entity is not None:
-        organisation, service = selected_entity.split(";")
         if active_tab == "chorus-dt":
             return chorus_dt.layout
         elif active_tab == "odrive":

--- a/app/src/apps/datasets.py
+++ b/app/src/apps/datasets.py
@@ -1,6 +1,0 @@
-import dash_html_components as html
-
-from apps import entity_choice
-from apps import data_display
-
-layout = html.Div(children=[entity_choice.layout, html.Hr(), data_display.layout])

--- a/app/src/apps/entity_choice.py
+++ b/app/src/apps/entity_choice.py
@@ -11,6 +11,8 @@ from app import app
 layout = html.Div(
     id="div-entity-choice",
     children=[
+        html.Div(id="div-url-redirect-to-dashboard", style={"display": "none"}),
+        html.Div(id="entity-choice-selected-entity", style={"display": "none"}),
         dcc.Dropdown(
             id="dropdown-entity-choice-level-1",
             options=oc.get_level_1_dropdown_items(),
@@ -37,7 +39,6 @@ layout = html.Div(
                 width={"size": 2, "offset": 5},
             )
         ),
-        html.Div(id="entity-choice-selected-entity", style={"display": "none"}),
     ],
 )
 
@@ -50,8 +51,7 @@ layout = html.Div(
 def on_click_go_to_dashboard(n_clicks, selected_entity):
     if n_clicks:
         organization, service = oc.get_organization_service(selected_entity)
-        search_page = "?entite=%s" % service.id
-        return dcc.Location(id="url-redirect", pathname="/tableau_de_bord", search=search_page)
+        return dcc.Location(id="url-redirect-to-dashboard", pathname="/tableau_de_bord/%s" % service.id)
 
 
 @app.callback(

--- a/app/src/apps/entity_choice.py
+++ b/app/src/apps/entity_choice.py
@@ -1,5 +1,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
+import dash_bootstrap_components as dbc
+
 from dash.dependencies import Output, Input, State
 
 from utils.organization_chart import oc
@@ -22,9 +24,34 @@ layout = html.Div(
             clearable=True,
             style={"margin": "10px", "display": "none"},
         ),
-        html.Div(id="selected-entity", style={"display": "none"}),
+        html.Hr(),
+        dbc.Row(
+            dbc.Col(
+                dbc.Button(
+                    "Vers le tableau de bord",
+                    id="button-to-dashboard",
+                    color="primary",
+                    className="mr-1",
+                    style={"display": "none"},
+                ),
+                width={"size": 2, "offset": 5},
+            )
+        ),
+        html.Div(id="entity-choice-selected-entity", style={"display": "none"}),
     ],
 )
+
+
+@app.callback(
+    Output("div-url-redirect-to-dashboard", "children"),
+    [Input("button-to-dashboard", "n_clicks")],
+    [State("entity-choice-selected-entity", "children")],
+)
+def on_click_go_to_dashboard(n_clicks, selected_entity):
+    if n_clicks:
+        organization, service = oc.get_organization_service(selected_entity)
+        search_page = "?entite=%s" % service.id
+        return dcc.Location(id="url-redirect", pathname="/tableau_de_bord", search=search_page)
 
 
 @app.callback(
@@ -48,11 +75,13 @@ def on_dropdown_level_1_value(value_level_1, level_2_style):
 
 
 @app.callback(
-    Output("selected-entity", "children"),
+    [Output("entity-choice-selected-entity", "children"), Output("button-to-dashboard", "style")],
     [Input("dropdown-entity-choice-level-1", "value"), Input("dropdown-entity-choice-level-2", "value")],
+    [State("button-to-dashboard", "style")],
 )
-def on_set_value_level_1_level_2(value_level_1, value_level_2):
+def on_set_value_level_1_level_2(value_level_1, value_level_2, button_to_dashboard_style):
     if value_level_1 is not None:
         if value_level_2 is not None:
-            return ";".join((value_level_1, value_level_2))
-    return None
+            button_to_dashboard_style["display"] = "block"
+            return ";".join((value_level_1, value_level_2)), button_to_dashboard_style
+    return None, button_to_dashboard_style

--- a/app/src/apps/home.py
+++ b/app/src/apps/home.py
@@ -8,6 +8,7 @@ from app import app
 layout = html.Div(
     id="div-header",
     children=[
+        html.Div(id="div-url-redirect-to-entity-choice", style={"display": "none"}),
         dbc.Row(
             dbc.Col(
                 html.Div(
@@ -53,4 +54,4 @@ layout = html.Div(
 @app.callback(Output("div-url-redirect-to-entity-choice", "children"), [Input("button-to-entity-choice", "n_clicks")])
 def on_click_go_to_entity_choice(n_clicks):
     if n_clicks:
-        return dcc.Location(id="url-redirect", pathname="/selection_entite")
+        return dcc.Location(id="url-redirect-to-entity-choice", pathname="/selection_entite")

--- a/app/src/apps/home.py
+++ b/app/src/apps/home.py
@@ -36,7 +36,13 @@ layout = html.Div(
         html.Hr(),
         dbc.Row(
             dbc.Col(
-                dbc.Button("Let's go", id="button-to-dataset", color="primary", className="mr-1", block=True),
+                dbc.Button(
+                    "Selectionnez votre entité",
+                    id="button-to-entity-choice",
+                    color="primary",
+                    className="mr-1",
+                    block=True,
+                ),
                 width={"size": 2, "offset": 5},
             )
         ),
@@ -44,7 +50,7 @@ layout = html.Div(
 )
 
 
-@app.callback(Output("div-url-redirect", "children"), [Input("button-to-dataset", "n_clicks")])
-def on_click_go_to_dataset(n_clicks):
+@app.callback(Output("div-url-redirect-to-entity-choice", "children"), [Input("button-to-entity-choice", "n_clicks")])
+def on_click_go_to_entity_choice(n_clicks):
     if n_clicks:
-        return dcc.Location(id="url-redirect", pathname="/datasets")
+        return dcc.Location(id="url-redirect", pathname="/selection_entite")

--- a/app/src/apps/odrive.py
+++ b/app/src/apps/odrive.py
@@ -72,19 +72,19 @@ layout = html.Div(
                     [
                         cards,
                         build_figure_container(
-                            title="Répartition par direction", id="donut-by-entity", footer="Explications..",
+                            title="Répartition par direction", id="donut-by-entity", footer="Explications.."
                         ),
                     ],
                     width=9,
                 ),
             ]
-        ),
+        )
     ],
     id="div-data-odrive",
 )
 
 
-@app.callback(Output("donut-by-entity", "figure"), [Input("selected-entity", "children")])
+@app.callback(Output("donut-by-entity", "figure"), [Input("dashboard-selected-entity", "children")])
 def update_donut_by_prestation(selected_entity):
-    organization, service = oc.get_organization_service(selected_entity)
+    service = oc.get_entity_by_id(selected_entity)
     return get_donut_by_entity_type(service.code_odrive)

--- a/app/src/apps/osfi.py
+++ b/app/src/apps/osfi.py
@@ -57,10 +57,10 @@ layout = html.Div(
         Output("emission-electricity-pie", "figure"),
         Output("emission-gas-pie", "figure"),
     ],
-    [Input("selected-entity", "children")],
+    [Input("dashboard-selected-entity", "children")],
 )
 def update_graphs(selected_entity):
-    organization, service = oc.get_organization_service(selected_entity)
+    service = oc.get_entity_by_id(selected_entity)
     data = oh.get_structure_data(service.code_osfi)
     columns = [{"name": i, "id": i} for i in data.columns]
     data_to_return = data.to_dict("records")

--- a/app/src/apps/osfi.py
+++ b/app/src/apps/osfi.py
@@ -21,7 +21,6 @@ def get_pie(data, column):
 
 layout = html.Div(
     [
-        # dbc.Row([dbc.Col([html.B("", id="osfi-selected-entity-show"),]),]),
         dbc.Row(
             dbc.Col(
                 build_table_container(

--- a/app/src/index.py
+++ b/app/src/index.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
@@ -24,15 +26,7 @@ navbar = dbc.Navbar(
 app.layout = html.Div(
     children=[
         dbc.Container(
-            [
-                html.Div(id="div-url-redirect-to-entity-choice"),
-                html.Div(id="div-url-redirect-to-dashboard"),
-                dcc.Location(id="url", refresh=False),
-                navbar,
-                html.Br(),
-                html.Div(id="page-content"),
-            ],
-            fluid=True,
+            [dcc.Location(id="url", refresh=False), navbar, html.Br(), html.Div(id="page-content")], fluid=True
         ),
         footer.layout,
     ]
@@ -48,12 +42,14 @@ def display_page(pathname):
         return home.layout
     elif pathname == "/selection_entite":
         return entity_choice.layout
-    elif pathname == "/tableau_de_bord":
+    elif isinstance(pathname, str) and pathname.startswith("/tableau_de_bord/"):
         return dashboard.layout
     elif pathname == "/a_propos":
         return about.layout
     elif pathname == "/methodologie":
         return methodology.layout
+    else:
+        return home.layout
 
 
 if __name__ == "__main__":

--- a/app/src/index.py
+++ b/app/src/index.py
@@ -5,7 +5,8 @@ import dash_bootstrap_components as dbc
 from dash.dependencies import Output, Input, State
 
 from apps import home
-from apps import datasets
+from apps import dashboard
+from apps import entity_choice
 from apps import about
 from apps import methodology
 from apps import footer
@@ -24,7 +25,8 @@ app.layout = html.Div(
     children=[
         dbc.Container(
             [
-                html.Div(id="div-url-redirect"),
+                html.Div(id="div-url-redirect-to-entity-choice"),
+                html.Div(id="div-url-redirect-to-dashboard"),
                 dcc.Location(id="url", refresh=False),
                 navbar,
                 html.Br(),
@@ -44,8 +46,10 @@ flask_app = app.server
 def display_page(pathname):
     if pathname == "/":
         return home.layout
-    elif pathname == "/datasets":
-        return datasets.layout
+    elif pathname == "/selection_entite":
+        return entity_choice.layout
+    elif pathname == "/tableau_de_bord":
+        return dashboard.layout
     elif pathname == "/a_propos":
         return about.layout
     elif pathname == "/methodologie":


### PR DESCRIPTION
A lot of files have been modified here.

The main goals were:
- add the entity choice page which will redirect to the dashboard page once the entity was selected
- get rid of the `get_organization_service function` (we never used the organization)
- allow the url of the dashboard to contain the entity (Now `http://localhost:5011/tableau_de_bord?entite=5`)

So the modifications are:
- minor modifications to the odrive / chorus-dt / osfi dashboards to change  `get_organization_service function` into `get_entity_by_id`
- the renaming of the `data_display` application to `dashboard` (:facepalm:)
- the deletion of the now useless `dataset` app
- in the dashboard, the url is parsed and the content of the search request is put into a div `dashboard-selected-entity`
- the addition of a button in the `entity_selection` layout to redirect to the `dashboard`.
